### PR TITLE
Update prometheus-net package to latest and upgrade target framework …

### DIFF
--- a/src/Akka.Monitoring.Prometheus.Demo/Akka.Monitoring.Prometheus.Demo.csproj
+++ b/src/Akka.Monitoring.Prometheus.Demo/Akka.Monitoring.Prometheus.Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.Monitoring.Prometheus/Akka.Monitoring.Prometheus.csproj
+++ b/src/Akka.Monitoring.Prometheus/Akka.Monitoring.Prometheus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Syncromatics Engineering</Authors>
     <Company>Syncromatics Corporation</Company>
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Akka.Monitoring" Version="1.1.0" />
     <PackageReference Include="DestructureExtensions" Version="2.1.0" />
-    <PackageReference Include="prometheus-net" Version="4.0.0" />
+    <PackageReference Include="prometheus-net" Version="8.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I recently upgraded my Akka.NET project to use v1.5.x and noticed Akka.Monitoring.Prometheus was not behaving appropriately. For instance, Gauge metric was not showing up at all.

Upgrading prometheus-net to latest fixed that. On top of that, updated TargetFramework to net7.0.